### PR TITLE
Change version_compare to version for compability with ansible-core 2.19.2

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,4 +6,4 @@ packages:
   - build-essential
   - ruby-dev
   - libmagickwand-dev
-  - "{{ 'libmariadbclient-dev' if ansible_distribution_version | version_compare('9', '>=') else 'libmysqlclient-dev' }}"
+  - "{{ 'libmariadbclient-dev' if ansible_distribution_version | version('9', '>=') else 'libmysqlclient-dev' }}"


### PR DESCRIPTION
In [Ansible documentation](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tests.html#comparing-versions), it's shown that `version_compare` was renamed to `version`, and most examples in the docs use `version` now. I had some problems with this in some cases in ansible-core 2.19.2 so I changed it.